### PR TITLE
Fix EF core warning

### DIFF
--- a/src/Dash/src/Dash/Dash.csproj
+++ b/src/Dash/src/Dash/Dash.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
-    <Version>0.5.0-alpha</Version>
+    <Version>0.5.1-alpha</Version>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-dash</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
@@ -12,7 +12,7 @@
     <Authors>Huy Hoang</Authors>
     <CodeAnalysisRuleSet>..\.sonarlint\dotnet-dash_dashcsharp.ruleset</CodeAnalysisRuleSet>
     <Description>Dash is a command-line tool for fast model-driven code generation.</Description>
-    <PackageReleaseNotes>Generated code now uses EF Fluent API to configure the generated POCO if such contraints are defined in the Model File.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed EF core warning: "The 'bool' property 'X' on entity type 'Y' is configured with a database-generated default. This default will always be used for inserts when the property has the value 'false', since this is the CLR default for the 'bool' type. Consider using the nullable 'bool?' type instead so that the default will only be used for inserts when the property value is 'null'."</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/dotnet-dash</PackageProjectUrl>
     <PackageIcon>packageicon.png</PackageIcon>
     <Copyright>Huy Hoang</Copyright>

--- a/src/Dash/src/Dash/Engine/TemplateTransformers/Scriban/CSharpOutputHelpers.cs
+++ b/src/Dash/src/Dash/Engine/TemplateTransformers/Scriban/CSharpOutputHelpers.cs
@@ -47,9 +47,19 @@ namespace Dash.Engine.TemplateTransformers.Scriban
             else if (value is AttributeModel attribute)
             {
                 if (attribute.DataType.IsNumeric ||
-                    attribute.DataType.IsDateTime ||
-                    attribute.DataType.IsBoolean)
+                    attribute.DataType.IsDateTime)
                 {
+                    return string.Empty;
+                }
+
+                if (attribute.DataType.IsBoolean)
+                {
+                    if (attribute.DefaultValue != null)
+                    {
+                        var booleanValue = GetCSharpLiteral(bool.Parse(attribute.DefaultValue));
+                        return $"= {booleanValue};";
+                    }
+
                     return string.Empty;
                 }
 

--- a/src/Dash/src/Dash/Templates/efcontext
+++ b/src/Dash/src/Dash/Templates/efcontext
@@ -31,7 +31,6 @@ namespace {{ namespace }}
         {{- if p.data_type.is_string }}.IsUnicode({{- p.data_type.is_unicode }}){{- end }}
         {{- if !p.is_nullable }}.IsRequired(){{- end }}
         {{- if p.max_length != null }}.HasMaxLength({{- p.max_length }}){{- end }}
-        {{- if p.default_value }}.HasDefaultValue({{- p.default_value | get_csharp_literal }}){{- end }}
         {{- if true }};{{- end }}
     {{- end }}
     {{- if e.seed_data.size > 0 }}

--- a/src/Dash/test/Dash.Tests/Engine/TemplateTransformers/Scriban/CSharpOutputHelpersTests.cs
+++ b/src/Dash/test/Dash.Tests/Engine/TemplateTransformers/Scriban/CSharpOutputHelpersTests.cs
@@ -15,13 +15,13 @@ namespace Dash.Tests.Engine.TemplateTransformers.Scriban
     {
         [Theory]
         [MemberData(nameof(Data), 2)]
-        public void GetCSharpLiteral_Null_ShouldReturnValueNull(object value, string expectedOutput)
+        public void GetCSharpLiteral_Value_ShouldReturnExpectedResult(object value, string expectedResult)
         {
             // Act
             var result = CSharpOutputHelpers.GetCSharpLiteral(value);
 
             // Assert
-            result.Should().Be(expectedOutput);
+            result.Should().Be(expectedResult);
         }
 
         public static IEnumerable<object?[]> Data =>
@@ -98,6 +98,24 @@ namespace Dash.Tests.Engine.TemplateTransformers.Scriban
 
             // Assert
             result.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public void GetPropertyDefaultValueAssignment_BooleanAttributeWithDefaultValue_ShouldReturnDefaultValue(string defaultValue)
+        {
+            // Arrange
+            var dataTypeParserResult = new DataTypeDeclarationParserResult(new BoolDataType())
+                .WithDefaultValue(defaultValue);
+
+            var attribute = new AttributeModel("foo", dataTypeParserResult, "bool");
+
+            // Act
+            var result = CSharpOutputHelpers.GetPropertyDefaultValueAssignment(attribute);
+
+            // Assert
+            result.Should().Be($"= {defaultValue};");
         }
     }
 }


### PR DESCRIPTION
The 'bool' property 'X' on entity type 'Y' is configured with a database-generated default. This default will always be used for inserts when the property has the value 'false', since this is the CLR default for the 'bool' type. Consider using the nullable 'bool?' type instead so that the default will only be used for inserts when the property value is 'null'."